### PR TITLE
Ensure disconnect flag reset on new connections

### DIFF
--- a/metor/core.py
+++ b/metor/core.py
@@ -119,6 +119,7 @@ def handle_incoming(conn, chat_manager):
             conn.close()
             return
         chat_manager.active_connection = conn
+        chat_manager.user_initiated_disconnect = False
 
     try:
         conn.settimeout(5)
@@ -367,6 +368,11 @@ class ChatManager:
                     pass
                 self.active_connection = None
                 self.active_remote_identity = None
+        if initiated_by_self:
+            if self.receiver_thread:
+                self.receiver_thread.join(timeout=1)
+                self.receiver_thread = None
+            self.user_initiated_disconnect = False
         return remote_identity
 
     def send_message(self, msg):
@@ -397,6 +403,7 @@ class ChatManager:
             return
         with self.connection_lock:
             self.active_connection = conn
+            self.user_initiated_disconnect = False
         identity_to_send = "anonymous" if anonymous else self.own_onion
         try:
             conn.sendall(f"/init {identity_to_send}\n".encode())


### PR DESCRIPTION
## Summary
- set `user_initiated_disconnect` to `False` when a connection is accepted or initiated
- join the receiver thread and clear the flag when disconnecting

## Testing
- `python -m py_compile metor/core.py`

------
https://chatgpt.com/codex/tasks/task_e_684494ea85748331a97e7e3af5a766ed