### PR TITLE
Fix chat input misalignment

### DIFF
--- a/metor/core.py
+++ b/metor/core.py
@@ -151,6 +151,7 @@ def print_message(msg, cli=None, skip_prompt=False):
     elif msg.startswith("info>"):
         msg = msg.replace("info>", f"{YELLOW}info>{RESET}", 1)
     sys.stdout.write(msg + "\n")
+    sys.stdout.write("\r")
     if not skip_prompt and cli is not None:
         sys.stdout.write(cli.prompt + cli.current_input)
         sys.stdout.flush()


### PR DESCRIPTION
## Summary
- ensure messages reset the cursor position

## Testing
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=64)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449b0e1efc8331b6c16100787957c6